### PR TITLE
Fix dead link to de-en.tgz

### DIFF
--- a/tools/prepare_mt_data.sh
+++ b/tools/prepare_mt_data.sh
@@ -100,7 +100,7 @@ TOKENIZER=$SCRIPTS/tokenizer/tokenizer.perl
 LC=$SCRIPTS/tokenizer/lowercase.perl
 CLEAN=$SCRIPTS/training/clean-corpus-n.perl
 
-URL="http://wit3.fbk.eu/archive/2014-01/texts/de/en/de-en.tgz"
+URL="http://dl.fbaipublicfiles.com/fairseq/data/iwslt14/de-en.tgz"
 GZ=de-en.tgz
 
 if [ ! -d "$SCRIPTS" ]; then


### PR DESCRIPTION
The old link has been dead since at least December 2020. I have changed it to the backup link provided by [myleott](https://github.com/myleott) in [this comment](https://github.com/facebookresearch/fairseq/issues/2984#issuecomment-755798354).